### PR TITLE
Add EruditePay — 352 blockchain analytics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ APIs
 - [Bitcoincharts](https://bitcoincharts.com/about/markets-api/) - You can use this API to include markets data in your websites, mobile apps or desktop applets.
 - [ShapeShift.io](https://shapeshift.io/) - Exchange between cryptocurrencies without an account.  Well documented API for easy use.
 - [Exchange Rates API](https://blockchain.info/api/exchange_rates_api) - Market Prices and exchanges rates api.
+- [EruditePay](https://bridge.eruditepay.com) - 352 blockchain analytics endpoints across Base, Tron, BTC, XRP, and Kaspa. Token prices, whale tracking, DeFi analytics, gas forecasting, NFT data, and security scanning. Pay-per-call with x402 micropayments.
 
 ### Captcha
 - [Google reCAPTCHA](https://developers.google.com/recaptcha/intro?hl=en) - ReCAPTCHA lets you embed a CAPTCHA in your web pages in order to protect them against spam and other types of automated abuse.


### PR DESCRIPTION
Adds EruditePay to the Bitcoin/Bitcoin Wallets section.

- 352 blockchain analytics endpoints across Base, Tron, BTC, XRP, and Kaspa
- Token prices, whale tracking, DeFi analytics, gas forecasting, NFT data, security scanning
- Pay-per-call with x402 micropayments (USDC/USDT)
- Live at https://bridge.eruditepay.com