### PR TITLE
Add API Snap to Miscellaneous section

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ APIs
 
 ### Miscellaneous
 
+- [API Snap](https://api-snap.com) - Free utility API platform — QR codes, screenshots, PDFs, image resize, hashing, and 8+ more tools under one API key. Free tier: 100 calls/month. 💸
 - [BBC](http://www.bbc.co.uk/developer/technology/apis.html) - Variety of BBC APIs with access to interesting data from Radio Labs, programs played on BBC and linking data around the artist played on BBC.
 - [MuseScore](http://developers.musescore.com/) - REST based API which provides music metadata.
 - [Spreaker](http://developers.spreaker.com/) - Enables developers to read and write data to Spreaker.


### PR DESCRIPTION
Add [API Snap](https://api-snap.com) to the Miscellaneous section.

API Snap is a free utility API platform — QR codes, screenshots, PDFs, image resize, hashing, and 8+ more tools under one API key. Free tier: 100 calls/month.